### PR TITLE
Minor API improvements

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# default empty rustfmt.toml to ensure that rustfmt doesn't pick up settings from the higher directories

--- a/src/model.rs
+++ b/src/model.rs
@@ -53,7 +53,7 @@ pub struct Requisition {
     pub id: String,
     pub created: String,
     pub redirect: String,
-    pub status: String,
+    pub status: RequisitionStatus,
     #[serde(rename = "institution_id")]
     pub institution_id: String,
     pub agreement: String,
@@ -67,6 +67,27 @@ pub struct Requisition {
     pub account_selection: bool,
     #[serde(rename = "redirect_immediate")]
     pub redirect_immediate: bool,
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RequisitionStatus {
+    #[default]
+    #[serde(rename = "CR")]
+    Created,
+    #[serde(rename = "GC")]
+    GivingConsent,
+    #[serde(rename = "UA")]
+    UndergoingAuthentication,
+    #[serde(rename = "RJ")]
+    Rejected,
+    #[serde(rename = "SA")]
+    SelectingAccounts,
+    #[serde(rename = "GA")]
+    GrantingAccess,
+    #[serde(rename = "LN")]
+    Linked,
+    #[serde(rename = "EX")]
+    Expired,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -178,13 +178,60 @@ pub struct AccountDetailsResponse {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
+    /// The account id of the given account in the financial institution
     pub resource_id: String,
     pub iban: Option<String>,
+    /// This data element is used for payment accounts which have no IBAN
     pub bban: Option<String>,
+    /// The BIC associated to the account
+    pub bic: Option<String>,
+    /// An alias to a payment account via a registered mobile phone number
+    pub msisdn: Option<String>,
+    /// Account currency
     pub currency: String,
+    /// Name of the legal account owner. If there is more than one owner, then e.g. two names might be noted here. For a corporate account, the corporate name is used for this attribute
     pub owner_name: Option<String>,
+    /// Address of the legal account owner
+    pub owner_address_unstructured: Option<String>,
+    /// Name of the account, as assigned by the financial institution
     pub name: Option<String>,
-    pub cash_account_type: String,
-    pub status: String,
-    pub masked_pan: Option<String>,
+    /// Name of the account as defined by the end user within online channels
+    pub display_name: Option<String>,
+    /// Specifications that might be provided by the financial institution - characteristics of the account - characteristics of the relevant card
+    pub details: Option<String>,
+    /// Product Name of the Bank for this account, proprietary definition
+    pub product: Option<String>,
+    /// ExternalCashAccountType1Code from ISO 20022
+    pub cash_account_type: Option<String>,
+    /// Account status, if this field is None, then the account is available in the sense of the specification
+    pub status: Option<AccountStatus>,
+    /// This data attribute is a field, where an financial institution can name a cash account associated to pending card transactions
+    pub linked_accounts: Option<String>,
+    /// Specifies the usage of the account
+    pub usage: Option<AccountUsage>,
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub enum AccountStatus {
+    #[default]
+    #[serde(rename = "enabled")]
+    /// Account is available
+    Enabled,
+    #[serde(rename = "deleted")]
+    /// Account is terminated
+    Deleted,
+    #[serde(rename = "blocked")]
+    /// Account is blocked e.g. for legal reasons
+    Blocked,
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub enum AccountUsage {
+    #[default]
+    #[serde(rename = "PRIV")]
+    /// Private personal account
+    Private,
+    #[serde(rename = "ORGA")]
+    /// Professional account
+    Professional,
 }


### PR DESCRIPTION
Hi, thank you for the crate! I've had to do some adjustments to fit my use case and I think they might be useful in general:
1. The `create_requisition` function now takes `agreement_id` and `reference` as `Option` as they are not required in the upstream API and omitting them allows you to choose the default requisition without creating one explicitly.
2. Updated the fields in `Accounts`: added comments, added new fields, added `Option` where necessary, replaced `String` with `enum` where applicable and dropped fields which are missing from the spec.

Please note that these changes are **not** backwards compatible.