### PR TITLE
Amended fn get_institutions to accept countries other than GB

### DIFF
--- a/examples/01_create_requisition/src/main.rs
+++ b/examples/01_create_requisition/src/main.rs
@@ -25,7 +25,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = Client::new(secret_id, secret_key).await?;
 
-    let institutions = client.get_institutions().await?;
+    let institutions = client.get_institutions("gb").await?;
     dbg!(&institutions);
 
     let starling_bank = institutions

--- a/src/client.rs
+++ b/src/client.rs
@@ -126,7 +126,7 @@ impl Client {
     /// let secret_id = "my_secret_id".to_string();
     /// let secret_key = "my_secret_key".to_string();
     /// let mut client = Client::new(secret_id, secret_key).await?;
-    /// let institutions = client.get_institutions().await?;
+    /// let institutions = client.get_institutions("gb").await?;
     /// ```
     ///
     /// This method requires that a token has been created and stored in the `created_token` field of the `Client` struct. If no token has been created, this method will return an error.

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,8 +4,7 @@ use serde_json::json;
 use crate::model::*;
 
 const URL_CREATE_TOKEN: &str = "https://bankaccountdata.gocardless.com/api/v2/token/new/";
-const URL_GET_INSTITUTIONS: &str =
-    "https://bankaccountdata.gocardless.com/api/v2/institutions/?country=gb"; // TODO: make country a variable
+const URL_GET_INSTITUTIONS: &str = "https://bankaccountdata.gocardless.com/api/v2/institutions/";
 const URL_CREATE_END_USER_AGREEMENT: &str =
     "https://bankaccountdata.gocardless.com/api/v2/agreements/enduser/";
 const URL_REQUISITIONS: &str = "https://bankaccountdata.gocardless.com/api/v2/requisitions/";
@@ -131,12 +130,15 @@ impl Client {
     /// ```
     ///
     /// This method requires that a token has been created and stored in the `created_token` field of the `Client` struct. If no token has been created, this method will return an error.
-    pub async fn get_institutions(&self) -> Result<Vec<Institution>, Box<dyn std::error::Error>> {
+    pub async fn get_institutions(
+        &self,
+        country: &str,
+    ) -> Result<Vec<Institution>, Box<dyn std::error::Error>> {
         let access_token = self.created_token.clone().unwrap().access;
 
         let response: Vec<Institution> = self
             .req_client
-            .get(URL_GET_INSTITUTIONS)
+            .get(format!("{URL_GET_INSTITUTIONS}?country={}", country))
             .header("Accept", "application/json")
             .header("Authorization", format!("Bearer {}", access_token))
             .send()


### PR DESCRIPTION
No built-in security was added to this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify a country code when retrieving institutions, allowing for country-specific results.

* **Documentation**
  * Updated usage examples to reflect the new requirement for a country code parameter when fetching institutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->